### PR TITLE
Create pull requests automatically when another repo requests it via the REST api

### DIFF
--- a/.github/workflows/on-new-release.yml
+++ b/.github/workflows/on-new-release.yml
@@ -1,0 +1,17 @@
+name: On New Release
+
+on: [repository_dispatch]
+
+jobs:
+  create-pull-request:
+    if: github.event.action == 'lsp-add-or-update-package'
+    runs-on: ubuntu-16.04
+    steps:
+      - uses: actions/checkout@v2
+      - run: python3 auto-update-repository.json <<<'${{ github.event.client_payload }}'
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          commit-message: '[auto] add or update package'
+          delete-branch: true
+          branch-suffix: random

--- a/auto-update-repository.py
+++ b/auto-update-repository.py
@@ -6,44 +6,44 @@ import os
 
 
 def update_package(package: Dict[str, Any], payload: Dict[str, str]) -> None:
-	package.clear()
-	package.update(payload)
+    package.clear()
+    package.update(payload)
 
 
 def create_package(repository: Dict[str, Any], payload: Dict[str, str]) -> None:
-	name = payload["name"]
-	packages = repository["packages"]
-	index_to_insert = len(packages)
-	for index, package in enumerate(packages):
-		current_name = package["name"]
-		if current_name < name:
-			continue
-		index_to_insert = index
-		break
-	new_package = {"name": name}  # type: Dict[str, Any]
-	packages.insert(index_to_insert, new_package)
-	update_package(new_package, payload)
+    name = payload["name"]
+    packages = repository["packages"]
+    index_to_insert = len(packages)
+    for index, package in enumerate(packages):
+        current_name = package["name"]
+        if current_name < name:
+            continue
+        index_to_insert = index
+        break
+    new_package = {"name": name}  # type: Dict[str, Any]
+    packages.insert(index_to_insert, new_package)
+    update_package(new_package, payload)
 
 
 def main() -> None:
-	payload = json.load(sys.stdin)
-	repository_path = pathlib.Path(__file__).parent / "repository.json"
-	with repository_path.open("r") as fp:
-		repository = json.load(fp)
-	name = payload["name"]
-	found = False
-	for package in repository["packages"]:
-		if package["name"] == name:
-			update_package(package, payload)
-			print("Update", name)
-			found = True
-			break
-	if not found:
-		create_package(repository, payload)
-		print("Add", name)
-	with repository_path.open("w") as fp:
-		json.dump(repository, fp, indent="\t", sort_keys=True)
+    payload = json.load(sys.stdin)
+    repository_path = pathlib.Path(__file__).parent / "repository.json"
+    with repository_path.open("r") as fp:
+        repository = json.load(fp)
+    name = payload["name"]
+    found = False
+    for package in repository["packages"]:
+        if package["name"] == name:
+            update_package(package, payload)
+            print("Update", name)
+            found = True
+            break
+    if not found:
+        create_package(repository, payload)
+        print("Add", name)
+    with repository_path.open("w") as fp:
+        json.dump(repository, fp, indent="\t", sort_keys=True)
 
 
 if __name__ == '__main__':
-	main()
+    main()

--- a/auto-update-repository.py
+++ b/auto-update-repository.py
@@ -1,0 +1,49 @@
+import json
+import sys
+import pathlib
+from typing import Dict, Any
+import os
+
+
+def update_package(package: Dict[str, Any], payload: Dict[str, str]) -> None:
+	package.clear()
+	package.update(payload)
+
+
+def create_package(repository: Dict[str, Any], payload: Dict[str, str]) -> None:
+	name = payload["name"]
+	packages = repository["packages"]
+	index_to_insert = len(packages)
+	for index, package in enumerate(packages):
+		current_name = package["name"]
+		if current_name < name:
+			continue
+		index_to_insert = index
+		break
+	new_package = {"name": name}  # type: Dict[str, Any]
+	packages.insert(index_to_insert, new_package)
+	update_package(new_package, payload)
+
+
+def main() -> None:
+	payload = json.load(sys.stdin)
+	repository_path = pathlib.Path(__file__).parent / "repository.json"
+	with repository_path.open("r") as fp:
+		repository = json.load(fp)
+	name = payload["name"]
+	found = False
+	for package in repository["packages"]:
+		if package["name"] == name:
+			update_package(package, payload)
+			print("Update", name)
+			found = True
+			break
+	if not found:
+		create_package(repository, payload)
+		print("Add", name)
+	with repository_path.open("w") as fp:
+		json.dump(repository, fp, indent="\t", sort_keys=True)
+
+
+if __name__ == '__main__':
+	main()


### PR DESCRIPTION
Another repo in this organization can do a rest api request when it publishes a new release. At least, that's the plan. It works at least locally somewhat. But I don't know how to test the workflow locally.