### PR TITLE
Remove "st3" release branch for LSP-pyright

### DIFF
--- a/repository.json
+++ b/repository.json
@@ -166,11 +166,7 @@
 			"name": "LSP-pyright",
 			"releases": [
 				{
-					"sublime_text": "3154 - 4069",
-					"tags": "st3-"
-				},
-				{
-					"sublime_text": ">=4070",
+					"sublime_text": ">=3154",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
With latest LSP3 release we'll be able to use the same branch for both
ST3 and ST4. Both dotted settings and parsing variables are supported.

https://github.com/sublimelsp/LSP-pyright/pull/19
