### PR TITLE
Fix review-bot to work with pypi version of st_package_reviewer

### DIFF
--- a/review_bot/run_repo_tests.py
+++ b/review_bot/run_repo_tests.py
@@ -164,12 +164,13 @@ def run_tests(spec):
             tmp_package_dir_pathlib = pathlib.Path(tmp_package_dir)
             for checker in file_checkers.get_checkers():
                 checker_obj = checker(tmp_package_dir_pathlib)
-                if checker == CheckMessages:
-                    for release_source in spec['releases']:
-                        if isinstance(release_source.get('tags'), str):
-                            checker_obj.add_prefix(release_source.get('tags'))
-                elif checker == CheckHasSublimeSyntax:
-                    checker_obj.set_selector(info['releases'][0]['sublime_text'])
+                # TODO(rchl): These depend on st_package_reviewer changes that are not in the main repo
+                # if checker == CheckMessages:
+                #     for release_source in spec['releases']:
+                #         if isinstance(release_source.get('tags'), str):
+                #             checker_obj.add_prefix(release_source.get('tags'))
+                # elif checker == CheckHasSublimeSyntax:
+                #     checker_obj.set_selector(info['releases'][0]['sublime_text'])
 
                 checker_obj.perform_check()
                 for failure in checker_obj.failures:


### PR DESCRIPTION
There are some small bits of functionality that are included in
packagecontrol.io repo but not upstreamed.