### PR TITLE
Allow "osx-arm64" (Apple M1) installing LSP-TexLab

### DIFF
--- a/repository.json
+++ b/repository.json
@@ -607,6 +607,7 @@
 				{
 					"platforms": [
 						"windows-x64",
+						"osx-arm64",
 						"osx-x64",
 						"linux-x64"
 					],


### PR DESCRIPTION
Some users of LSP-TexLab have problems with `osx-arm64` platform because LSP-TexLab assumed it only supports x64 arch (because there are only official x64 pre-built binary). 

- https://github.com/sublimelsp/LSP-TexLab/issues/8
- https://github.com/sublimelsp/LSP-TexLab/issues/9

After some adjustments in LSP-TexLab's codes, it allows the user to use its own built binary now (see https://github.com/sublimelsp/LSP-TexLab#for-apple-m1-users).