### PR TITLE
Update default tag for LSP-metals

### DIFF
--- a/repository.json
+++ b/repository.json
@@ -470,7 +470,11 @@
 			],
 			"releases": [
 				{
-					"sublime_text": ">=3092",
+					"sublime_text": "3092 - 3999",
+					"tags": "st3-"
+				},
+				{
+					"sublime_text": ">=4000",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
After https://github.com/scalameta/metals-sublime/pull/57 LSP-metals will be ST4 only
I created a last tag for ST3 https://github.com/scalameta/metals-sublime/releases/tag/st3-v0.9.0