### PR TITLE
Add `LSP-prisma`.

### DIFF
--- a/repository.json
+++ b/repository.json
@@ -492,6 +492,23 @@
 			]
 		},
 		{
+			"details": "https://github.com/Sublime-Instincts/LSP-prisma",
+			"name": "LSP-prisma",
+			"labels": [
+				"auto-complete",
+				"linting",
+				"formatting",
+				"code navigation",
+				"intellisense"
+			],
+			"releases": [
+				{
+					"sublime_text": ">=4126",
+					"tags": true
+				}
+			]
+		},
+		{
 			"details": "https://github.com/prometheus-community/sublimelsp-promql",
 			"name": "LSP-promql",
 			"labels": [


### PR DESCRIPTION
This PR adds `LSP-prisma` (https://github.com/Sublime-Instincts/LSP-prisma)

`LSP-prisma` is a LSP helper package that uses the `Prisma Language Tools` to provide LSP support for Prisma schema files.