### PR TITLE
Add LSP-Grammarly

### DIFF
--- a/repository.json
+++ b/repository.json
@@ -285,6 +285,19 @@
 			]
 		},
 		{
+			"details": "https://github.com/sublimelsp/LSP-Grammarly",
+			"name": "LSP-Grammarly",
+			"labels": [
+				"linting"
+			],
+			"releases": [
+				{
+					"sublime_text": ">=4070",
+					"tags": true
+				}
+			]
+		},
+		{
 			"details": "https://github.com/sublimelsp/LSP-graphql",
 			"name": "LSP-graphql",
 			"labels": [


### PR DESCRIPTION
LSP-Grammarly is a small helper package that downloads and interfaces with the [Grammarly language server](https://github.com/znck/grammarly) to get [Grammarly](https://grammarly.com/)'s typing assistance in sublime.