### PR TITLE
Rename repository from LSP-leo to LSP-aleo-developer

### DIFF
--- a/repository.json
+++ b/repository.json
@@ -447,10 +447,10 @@
 			]
 		},
 		{
-			"details": "https://github.com/sublimelsp/LSP-leo",
-			"name": "LSP-leo",
+			"details": "https://github.com/sublimelsp/LSP-aleo-developer",
+			"name": "LSP-aleo-developer",
 			"author": "aleohq",
-			"homepage": "http://leo-lang.org/",
+			"homepage": "https://developer.aleo.org/overview/",
 			"issues": "https://github.com/AleoHQ/leo-plugins/issues",
 			"labels": [
 				"aleo",

--- a/repository.json
+++ b/repository.json
@@ -449,6 +449,7 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-aleo-developer",
 			"name": "LSP-aleo-developer",
+			"previous_names": ["LSP-leo"],
 			"author": "aleohq",
 			"homepage": "https://developer.aleo.org/overview/",
 			"issues": "https://github.com/AleoHQ/leo-plugins/issues",


### PR DESCRIPTION
We are adding support for the Aleo language https://developer.aleo.org/aleo/overview/. 
The Leo and Aleo languages are used to create programs in the Aleo network.
LSP for both of them is needed to create a program.
To allow users to work with both languages by installing one package we want to change the name of the repository and the description of this package.

Previous PR for LSP-leo https://github.com/sublimelsp/repository/pull/51
