### PR TITLE
Rename repository LSP-aleo-developer to LSP-leo

### DIFF
--- a/repository.json
+++ b/repository.json
@@ -447,9 +447,9 @@
 			]
 		},
 		{
-			"details": "https://github.com/sublimelsp/LSP-aleo-developer",
-			"name": "LSP-aleo-developer",
-			"previous_names": ["LSP-leo"],
+			"details": "https://github.com/sublimelsp/LSP-leo",
+			"name": "LSP-leo",
+			"previous_names": ["LSP-aleo-developer"],
 			"author": "aleohq",
 			"homepage": "https://developer.aleo.org/overview/",
 			"issues": "https://github.com/AleoHQ/leo-plugins/issues",


### PR DESCRIPTION
We need to change the name of the package and the repository name once again.


Previous PR for LSP-aleo-developer https://github.com/sublimelsp/repository/pull/68