### PR TITLE
LSP-pyright is ST4-only in newer releases

### DIFF
--- a/repository.json
+++ b/repository.json
@@ -641,7 +641,11 @@
 			],
 			"releases": [
 				{
-					"sublime_text": ">=3154",
+					"sublime_text": "3154 - 3999",
+					"tags": "st3-"
+				},
+				{
+					"sublime_text": ">=4000",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
@rchl 

- I've tagged both `1.2.19` and `st3-1.2.19` on https://github.com/sublimelsp/LSP-pyright/releases. `1.2.20` is planned to be ST4-only.
- I've created `st3` branch as a record. The `master` branch will be for ST 4.
- We drop ST3 support because the inherited default Python syntax is now `version:2` as of ST 4148. `version:2` syntax is a new feature of ST 4. Related PR: https://github.com/sublimelsp/LSP-pyright/pull/224