### PR TITLE
Cut LSP-pyright for ST>=4148

### DIFF
--- a/repository.json
+++ b/repository.json
@@ -641,11 +641,11 @@
 			],
 			"releases": [
 				{
-					"sublime_text": "3154 - 3999",
+					"sublime_text": "3154 - 4147",
 					"tags": "st3-"
 				},
 				{
-					"sublime_text": ">=4000",
+					"sublime_text": ">=4148",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
As of ST 4148, the Python syntax uses "version: 2".

So the actually cut point is not ST 4 but ST 4148... I guess I would've to release both branch for a while until there is a new ST stable build.