### PR TITLE
Add LSP-VHDL-ls

### DIFF
--- a/repository.json
+++ b/repository.json
@@ -855,6 +855,21 @@
 			]
 		},
 		{
+			"details": "https://github.com/martinbarez/LSP-VHDL-ls",
+			"name": "LSP-VHDL-ls",
+			"labels": ["VHDL"],
+			"releases": [
+				{
+					"sublime_text": ">=4070",
+					"platforms": [
+						"windows",
+						"linux"
+					],
+					"tags": true
+				}
+			]
+		},
+		{
 			"details": "https://github.com/sublimelsp/LSP-volar",
 			"name": "LSP-volar",
 			"labels": [


### PR DESCRIPTION
My package adds a VHDL LSP server to Sublime Text. It just adds a native way to install and use [rust_hdl](https://github.com/VHDL-LS/rust_hdl).