### PR TITLE
Restrict LSP-... helper packages to LSP's least ST build

### DIFF
--- a/repository.json
+++ b/repository.json
@@ -129,7 +129,7 @@
 			],
 			"releases": [
 				{
-					"sublime_text": ">=3092",
+					"sublime_text": ">=3154",
 					"tags": true
 				}
 			]
@@ -214,7 +214,7 @@
 			],
 			"releases": [
 				{
-					"sublime_text": ">=3092",
+					"sublime_text": ">=3154",
 					"tags": true
 				}
 			]
@@ -265,7 +265,7 @@
 			],
 			"releases": [
 				{
-					"sublime_text": ">=3092",
+					"sublime_text": ">=3154",
 					"tags": true
 				}
 			]
@@ -282,7 +282,7 @@
 			],
 			"releases": [
 				{
-					"sublime_text": ">=3092",
+					"sublime_text": ">=3154",
 					"tags": true
 				}
 			]
@@ -299,7 +299,7 @@
 			],
 			"releases": [
 				{
-					"sublime_text": ">=3092",
+					"sublime_text": ">=3154",
 					"tags": true
 				}
 			]
@@ -312,7 +312,7 @@
 			],
 			"releases": [
 				{
-					"sublime_text": "3092 - 3999",
+					"sublime_text": "3154 - 3999",
 					"tags": "st3-"
 				},
 				{
@@ -383,7 +383,7 @@
 			],
 			"releases": [
 				{
-					"sublime_text": ">=3092",
+					"sublime_text": ">=3154",
 					"tags": true
 				}
 			]
@@ -400,7 +400,7 @@
 			],
 			"releases": [
 				{
-					"sublime_text": ">=3092",
+					"sublime_text": ">=3154",
 					"tags": true
 				}
 			]
@@ -417,7 +417,7 @@
 			],
 			"releases": [
 				{
-					"sublime_text": ">=3092",
+					"sublime_text": ">=3154",
 					"tags": true
 				}
 			]
@@ -451,7 +451,7 @@
 			],
 			"releases": [
 				{
-					"sublime_text": ">=3092",
+					"sublime_text": ">=3154",
 					"tags": true
 				}
 			]
@@ -564,7 +564,7 @@
 			],
 			"releases": [
 				{
-					"sublime_text": "3092 - 3999",
+					"sublime_text": "3154 - 3999",
 					"tags": "st3-"
 				},
 				{
@@ -629,7 +629,7 @@
 			],
 			"releases": [
 				{
-					"sublime_text": ">=3092",
+					"sublime_text": ">=3154",
 					"tags": true
 				}
 			]
@@ -715,7 +715,7 @@
 			],
 			"releases": [
 				{
-					"sublime_text": "3092 - 3999",
+					"sublime_text": "3154 - 3999",
 					"tags": true
 				}
 			]
@@ -742,7 +742,7 @@
 			],
 			"releases": [
 				{
-					"sublime_text": ">=3092",
+					"sublime_text": ">=3154",
 					"tags": true
 				}
 			]
@@ -776,7 +776,7 @@
 			],
 			"releases": [
 				{
-					"sublime_text": ">=3092",
+					"sublime_text": ">=3154",
 					"tags": true
 				}
 			]
@@ -790,7 +790,7 @@
 			],
 			"releases": [
 				{
-					"sublime_text": ">=3092",
+					"sublime_text": ">=3154",
 					"tags": true
 				}
 			]
@@ -844,7 +844,7 @@
 			],
 			"releases": [
 				{
-					"sublime_text": "3092 - 3999",
+					"sublime_text": "3154 - 3999",
 					"tags": "st3-"
 				},
 				{
@@ -896,7 +896,7 @@
 			],
 			"releases": [
 				{
-					"sublime_text": ">=3092",
+					"sublime_text": ">=3154",
 					"tags": true
 				}
 			]
@@ -913,7 +913,7 @@
 			],
 			"releases": [
 				{
-					"sublime_text": ">=3092",
+					"sublime_text": ">=3154",
 					"tags": true
 				}
 			]
@@ -930,7 +930,7 @@
 			],
 			"releases": [
 				{
-					"sublime_text": ">=3092",
+					"sublime_text": ">=3154",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
It doesn't make sense to allow installing helper packages on ST3092 if LSP is requires at least ST3154.

Hence this commit restricts all helpers to LSP's least ST build.