### PR TITLE
Separate lsp_utils releases for ST3/4

### DIFF
--- a/repository.json
+++ b/repository.json
@@ -9,7 +9,12 @@
 			"releases": [
 				{
 					"base": "https://github.com/sublimelsp/lsp_utils",
-					"sublime_text": ">=3000",
+					"sublime_text": "3000 - 4069",
+					"tags": "st3-v"
+				},
+				{
+					"base": "https://github.com/sublimelsp/lsp_utils",
+					"sublime_text": ">=4070",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
lsp_utils 2.x is last compatible ST3 release

As of 3.0.0 ST4070+ is requied.

This PR makes required changes for Package control to pick up correct versions.