### PR TITLE
Separate LSP-css/html releases for ST3/4

### DIFF
--- a/repository.json
+++ b/repository.json
@@ -229,7 +229,11 @@
 			],
 			"releases": [
 				{
-					"sublime_text": ">=3154",
+					"sublime_text": "3154 - 4147",
+					"tags": "st3-"
+				},
+				{
+					"sublime_text": ">=4148",
 					"tags": true
 				}
 			]
@@ -431,7 +435,11 @@
 			],
 			"releases": [
 				{
-					"sublime_text": ">=3154",
+					"sublime_text": "3154 - 4147",
+					"tags": "st3-"
+				},
+				{
+					"sublime_text": ">=4148",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
They have been not working for ST 3 for quite a while actually...

https://github.com/sublimelsp/LSP-css/issues/46
https://github.com/sublimelsp/LSP-html/issues/45

By the way, LSP-json is reported too. https://github.com/sublimelsp/LSP-css/issues/46#issuecomment-1826738397

---

I have created `st3` branch and release tag for LSP-css/html, so this PR should be safe to merge.