### PR TITLE
Separate LSP-yaml releases for ST3/4

### DIFF
--- a/repository.json
+++ b/repository.json
@@ -990,7 +990,11 @@
 			],
 			"releases": [
 				{
-					"sublime_text": ">=3154",
+					"sublime_text": "3154 - 4147",
+					"tags": "st3-"
+				},
+				{
+					"sublime_text": ">=4148",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
The latest LSP-yaml still works on ST 3 but I don't think devs want to test it for ST 3 for every future release and we may forget to test. So, let's just leave it alone.