### PR TITLE
LSP-* versions should be based on the min/max version of LSP

### DIFF
--- a/repository.json
+++ b/repository.json
@@ -1010,7 +1010,7 @@
 					"tags": "st3-"
 				},
 				{
-					"sublime_text": ">=4070",
+					"sublime_text": ">=4148",
 					"tags": true
 				}
 			]

--- a/repository.json
+++ b/repository.json
@@ -197,7 +197,7 @@
 			],
 			"releases": [
 				{
-					"sublime_text": ">=4070",
+					"sublime_text": ">=4126",
 					"tags": true
 				}
 			]
@@ -512,7 +512,7 @@
 			],
 			"releases": [
 				{
-					"sublime_text": ">=4070",
+					"sublime_text": ">=4095",
 					"tags": true
 				}
 			]

--- a/repository.json
+++ b/repository.json
@@ -9,7 +9,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/sublimelsp/lsp_utils",
-					"sublime_text": "3000 - 4069",
+					"sublime_text": "3154 - 4069",
 					"tags": "st3-v"
 				},
 				{
@@ -229,11 +229,11 @@
 			],
 			"releases": [
 				{
-					"sublime_text": "3154 - 4147",
+					"sublime_text": "3154 - 4069",
 					"tags": "st3-"
 				},
 				{
-					"sublime_text": ">=4148",
+					"sublime_text": ">=4070",
 					"tags": true
 				}
 			]
@@ -331,11 +331,11 @@
 			],
 			"releases": [
 				{
-					"sublime_text": "3154 - 3999",
+					"sublime_text": "3154 - 4069",
 					"tags": "st3-"
 				},
 				{
-					"sublime_text": ">=4000",
+					"sublime_text": ">=4070",
 					"tags": true
 				}
 			]
@@ -435,11 +435,11 @@
 			],
 			"releases": [
 				{
-					"sublime_text": "3154 - 4147",
+					"sublime_text": "3154 - 4069",
 					"tags": "st3-"
 				},
 				{
-					"sublime_text": ">=4148",
+					"sublime_text": ">=4070",
 					"tags": true
 				}
 			]
@@ -490,11 +490,11 @@
 			],
 			"releases": [
 				{
-					"sublime_text": "3154 - 4147",
+					"sublime_text": "3154 - 4069",
 					"tags": "st3-"
 				},
 				{
-					"sublime_text": ">=4148",
+					"sublime_text": ">=4070",
 					"tags": true
 				}
 			]
@@ -512,7 +512,7 @@
 			],
 			"releases": [
 				{
-					"sublime_text": ">=4095",
+					"sublime_text": ">=4070",
 					"tags": true
 				}
 			]
@@ -626,11 +626,11 @@
 			],
 			"releases": [
 				{
-					"sublime_text": "3154 - 3999",
+					"sublime_text": "3154 - 4069",
 					"tags": "st3-"
 				},
 				{
-					"sublime_text": ">=4000",
+					"sublime_text": ">=4070",
 					"tags": true
 				}
 			]
@@ -674,7 +674,7 @@
 			],
 			"releases": [
 				{
-					"sublime_text": ">=4126",
+					"sublime_text": ">=4070",
 					"tags": true
 				}
 			]
@@ -718,11 +718,11 @@
 			],
 			"releases": [
 				{
-					"sublime_text": "3154 - 4147",
+					"sublime_text": "3154 - 4069",
 					"tags": "st3-"
 				},
 				{
-					"sublime_text": ">=4148",
+					"sublime_text": ">=4070",
 					"tags": true
 				}
 			]
@@ -787,7 +787,7 @@
 			],
 			"releases": [
 				{
-					"sublime_text": "3154 - 3999",
+					"sublime_text": "3154 - 4069",
 					"tags": true
 				}
 			]
@@ -916,11 +916,11 @@
 			],
 			"releases": [
 				{
-					"sublime_text": "3154 - 3999",
+					"sublime_text": "3154 - 4069",
 					"tags": "st3-"
 				},
 				{
-					"sublime_text": ">=4000",
+					"sublime_text": ">=4070",
 					"tags": true
 				}
 			]
@@ -968,11 +968,11 @@
 			],
 			"releases": [
 				{
-					"sublime_text": "3154 - 4147",
+					"sublime_text": "3154 - 4069",
 					"tags": "st3-"
 				},
 				{
-					"sublime_text": ">=4148",
+					"sublime_text": ">=4070",
 					"tags": true
 				}
 			]
@@ -1006,11 +1006,11 @@
 			],
 			"releases": [
 				{
-					"sublime_text": "3154 - 4147",
+					"sublime_text": "3154 - 4069",
 					"tags": "st3-"
 				},
 				{
-					"sublime_text": ">=4148",
+					"sublime_text": ">=4070",
 					"tags": true
 				}
 			]

--- a/repository.json
+++ b/repository.json
@@ -33,7 +33,7 @@
 			],
 			"releases": [
 				{
-					"sublime_text": ">=4000",
+					"sublime_text": ">=4070",
 					"tags": true
 				}
 			]
@@ -197,7 +197,7 @@
 			],
 			"releases": [
 				{
-					"sublime_text": ">=4126",
+					"sublime_text": ">=4070",
 					"tags": true
 				}
 			]
@@ -212,7 +212,7 @@
 			],
 			"releases": [
 				{
-					"sublime_text": ">=4126",
+					"sublime_text": ">=4070",
 					"tags": true
 				}
 			]

--- a/repository.json
+++ b/repository.json
@@ -972,7 +972,7 @@
 					"tags": "st3-"
 				},
 				{
-					"sublime_text": ">=4070",
+					"sublime_text": ">=4148",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
Hello,

`LSP` is the main package that each LSP-* package imports,
so it makes sense that the version that the LSP-* packages specify, **should** match the min/max version of LSP,
which is:
ST 3 - `3154 -4069`
ST 4 - `>=4070`

I have noticed the the versions of LSP-* that plugins specify are not consistent, or are sometimes even wrong(`"sublime_text": "3154 - 4147" - a release for ST3`). So I decided to clean that up.

cc @jfcherng, @jwortmann, @rchl,  @rwols  