### PR TITLE
LSP-tagml and LSP-promql support only ST3

### DIFF
--- a/repository.json
+++ b/repository.json
@@ -691,7 +691,7 @@
 			],
 			"releases": [
 				{
-					"sublime_text": ">=3154",
+					"sublime_text": "3154 - 4069",
 					"tags": true
 				}
 			]
@@ -848,7 +848,7 @@
 			],
 			"releases": [
 				{
-					"sublime_text": ">=3154",
+					"sublime_text": "3154 - 4069",
 					"tags": true
 				}
 			]


### PR DESCRIPTION
These two packages only work in ST3.
We get an import error in ST4.