### PR TITLE
add LSP-vetur

### DIFF
--- a/repository.json
+++ b/repository.json
@@ -1041,6 +1041,27 @@
 			]
 		},
 		{
+			"details": "https://github.com/sublimelsp/LSP-vetur",
+			"name": "LSP-vetur",
+			"labels": [
+				"auto-complete",
+				"linting",
+				"formatting",
+				"code navigation",
+				"intellisense"
+			],
+			"releases": [
+				{
+					"sublime_text": "3154 - 3999",
+					"tags": "st3-"
+				},
+				{
+					"sublime_text": ">=4000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"details": "https://github.com/martinbarez/LSP-VHDL-ls",
 			"name": "LSP-VHDL-ls",
 			"labels": [


### PR DESCRIPTION
LSP-vetur is a mirror of no longer maintained LSP-vue.

I have plans to make LSP-vue into the main/official language server based on Vue language features 2.x (LSP-volar is based on Vue language features 1.x which is not compatible with 2.x).

It's a bit of a non-standard approach and it will break flow for users of LSP-vue but:
a) LSP-vue was always badly named for what it was (should have been LSP-vetur from the start)
b) Vetur is no longer maintained and it makes it look bad to make it look like this is the official server for Vue.