### PR TITLE
Reduce the number of labels

### DIFF
--- a/repository.json
+++ b/repository.json
@@ -56,7 +56,7 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-angular",
 			"name": "LSP-angular",
-			"labels": ["lsp"],
+			"labels": ["lsp", "angular"],
 			"releases": [
 				{
 					"sublime_text": "3154 - 3999",
@@ -71,7 +71,7 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-astro",
 			"name": "LSP-astro",
-			"labels": ["lsp"],
+			"labels": ["lsp", "astro"],
 			"releases": [
 				{
 					"sublime_text": ">=4070",
@@ -93,7 +93,7 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-bash",
 			"name": "LSP-bash",
-			"labels": ["lsp"],
+			"labels": ["lsp", "bash"],
 			"releases": [
 				{
 					"sublime_text": "3154 - 3999",
@@ -108,7 +108,7 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-Bicep",
 			"name": "LSP-Bicep",
-			"labels": ["lsp"],
+			"labels": ["lsp", "bicep"],
 			"releases": [
 				{
 					"sublime_text": ">=4070",
@@ -119,7 +119,7 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-biome",
 			"name": "LSP-biome",
-			"labels": ["lsp"],
+			"labels": ["lsp", "javascript", "typescript", "json", "html", "css", "graphql"],
 			"releases": [
 				{
 					"sublime_text": ">=4070",
@@ -145,7 +145,7 @@
 				"TheSecEng",
 				"jfcherng"
 			],
-			"labels": ["lsp"],
+			"labels": ["lsp", "ai"],
 			"releases": [
 				{
 					"sublime_text": ">=4126",
@@ -185,7 +185,7 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-Dart",
 			"name": "LSP-Dart",
-			"labels": ["lsp"],
+			"labels": ["lsp", "dart"],
 			"releases": [
 				{
 					"sublime_text": ">=4070",
@@ -196,7 +196,7 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-Deno",
 			"name": "LSP-Deno",
-			"labels": ["lsp", "javascript", "jsx", "typescript", "tsx"],
+			"labels": ["lsp", "javascript", "typescript"],
 			"releases": [
 				{
 					"sublime_text": ">=4070",
@@ -207,7 +207,7 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-dockerfile",
 			"name": "LSP-dockerfile",
-			"labels": ["lsp"],
+			"labels": ["lsp", "docker"],
 			"releases": [
 				{
 					"sublime_text": "3154 - 3999",
@@ -222,7 +222,7 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-elixir",
 			"name": "LSP-elixir",
-			"labels": ["lsp"],
+			"labels": ["lsp", "elixir"],
 			"releases": [
 				{
 					"sublime_text": "3154 - 3999",
@@ -237,7 +237,7 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-elm",
 			"name": "LSP-elm",
-			"labels": ["lsp"],
+			"labels": ["lsp", "elm"],
 			"releases": [
 				{
 					"sublime_text": "3154 - 3999",
@@ -252,7 +252,7 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-eslint",
 			"name": "LSP-eslint",
-			"labels": ["lsp", "javascript", "jsx", "typescript", "tsx"],
+			"labels": ["lsp", "javascript", "typescript"],
 			"releases": [
 				{
 					"sublime_text": "3154 - 3999",
@@ -278,7 +278,7 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-flow",
 			"name": "LSP-flow",
-			"labels": ["lsp"],
+			"labels": ["lsp", "flow"],
 			"releases": [
 				{
 					"sublime_text": ">=4070",
@@ -290,7 +290,7 @@
 			"details": "https://github.com/jdkato/LSP-gnols",
 			"name": "LSP-gnols",
 			"author": "jdkato",
-			"labels": ["lsp"],
+			"labels": ["lsp", "gno"],
 			"releases": [
 				{
 					"sublime_text": ">=4070",
@@ -326,7 +326,7 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-graphql",
 			"name": "LSP-graphql",
-			"labels": ["lsp"],
+			"labels": ["lsp", "graphql"],
 			"releases": [
 				{
 					"sublime_text": "3154 - 3999",
@@ -341,7 +341,7 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-html",
 			"name": "LSP-html",
-			"labels": ["lsp"],
+			"labels": ["lsp", "html"],
 			"releases": [
 				{
 					"sublime_text": "3154 - 4147",
@@ -382,7 +382,7 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-json",
 			"name": "LSP-json",
-			"labels": ["lsp"],
+			"labels": ["lsp", "json"],
 			"releases": [
 				{
 					"sublime_text": "3154 - 4147",
@@ -397,7 +397,7 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-julia",
 			"name": "LSP-julia",
-			"labels": ["lsp"],
+			"labels": ["lsp", "julia"],
 			"releases": [
 				{
 					"sublime_text": ">=4095",
@@ -423,7 +423,7 @@
 		{
 			"name": "LSP-lemminx",
 			"details": "https://github.com/sublimelsp/LSP-lemminx",
-			"labels": ["lsp"],
+			"labels": ["lsp", "xml"],
 			"releases": [
 				{
 					"sublime_text": "3154 - 4069",
@@ -475,7 +475,7 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-lua",
 			"name": "LSP-lua",
-			"labels": ["lsp"],
+			"labels": ["lsp", "lua"],
 			"releases": [
 				{
 					"sublime_text": ">=4070",
@@ -497,7 +497,7 @@
 		{
 			"details": "https://github.com/scalameta/metals-sublime",
 			"name": "LSP-metals",
-			"labels": ["lsp"],
+			"labels": ["lsp", "scala"],
 			"releases": [
 				{
 					"sublime_text": "3154 - 3999",
@@ -512,7 +512,7 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-nimlangserver",
 			"name": "LSP-nimlangserver",
-			"labels": ["lsp"],
+			"labels": ["lsp", "nim"],
 			"releases": [
 				{
 					"sublime_text": ">=4070",
@@ -534,7 +534,7 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-PowerShellEditorServices",
 			"name": "LSP-PowerShellEditorServices",
-			"labels": ["lsp"],
+			"labels": ["lsp", "powershell"],
 			"releases": [
 				{
 					"sublime_text": ">=4070",
@@ -545,7 +545,7 @@
 		{
 			"details": "https://github.com/Sublime-Instincts/LSP-prisma",
 			"name": "LSP-prisma",
-			"labels": ["lsp"],
+			"labels": ["lsp", "prisma"],
 			"releases": [
 				{
 					"sublime_text": ">=4126",
@@ -556,7 +556,7 @@
 		{
 			"details": "https://github.com/prometheus-community/sublimelsp-promql",
 			"name": "LSP-promql",
-			"labels": ["lsp"],
+			"labels": ["lsp", "promql"],
 			"releases": [
 				{
 					"sublime_text": "3154 - 4069",
@@ -613,7 +613,7 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-R",
 			"name": "LSP-R",
-			"labels": ["lsp"],
+			"labels": ["lsp", "r"],
 			"releases": [
 				{
 					"sublime_text": ">=4070",
@@ -624,7 +624,7 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-rome",
 			"name": "LSP-rome",
-			"labels": ["lsp"],
+			"labels": ["lsp", "javascript", "typescript"],
 			"releases": [
 				{
 					"sublime_text": ">=4070",
@@ -636,7 +636,7 @@
 			"details": "https://github.com/sublimelsp/LSP-ruff",
 			"name": "LSP-ruff",
 			"author": "LDAP",
-			"labels": ["lsp"],
+			"labels": ["lsp", "python"],
 			"releases": [
 				{
 					"sublime_text": "3154 - 3999",
@@ -651,7 +651,7 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-rust-analyzer",
 			"name": "LSP-rust-analyzer",
-			"labels": ["lsp"],
+			"labels": ["lsp", "rust"],
 			"releases": [
 				{
 					"sublime_text": ">=4070",
@@ -699,7 +699,7 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-stylelint",
 			"name": "LSP-stylelint",
-			"labels": ["lsp"],
+			"labels": ["lsp", "css", "scss", "less"],
 			"releases": [
 				{
 					"sublime_text": "3154 - 3999",
@@ -714,7 +714,7 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-svelte",
 			"name": "LSP-svelte",
-			"labels": ["lsp"],
+			"labels": ["lsp", "svelte"],
 			"releases": [
 				{
 					"sublime_text": "3154 - 3999",
@@ -729,7 +729,7 @@
 		{
 			"details": "https://github.com/HuygensING/LSP-tagml",
 			"name": "LSP-tagml",
-			"labels": ["lsp"],
+			"labels": ["lsp", "tagml"],
 			"releases": [
 				{
 					"sublime_text": "3154 - 4069",
@@ -755,7 +755,7 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-taplo",
 			"name": "LSP-taplo",
-			"labels": ["lsp"],
+			"labels": ["lsp", "toml"],
 			"releases": [
 				{
 					"sublime_text": ">=4070",
@@ -769,7 +769,7 @@
 			"previous_names": [
 				"LSP-Terraform"
 			],
-			"labels": ["lsp"],
+			"labels": ["lsp", "terraform"],
 			"releases": [
 				{
 					"sublime_text": ">=4070",
@@ -791,7 +791,7 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-typescript",
 			"name": "LSP-typescript",
-			"labels": ["lsp", "javascript", "jsx", "typescript", "tsx"],
+			"labels": ["lsp", "javascript", "typescript"],
 			"releases": [
 				{
 					"sublime_text": "3154 - 3999",
@@ -818,7 +818,7 @@
 			"details": "https://github.com/errata-ai/LSP-vale-ls",
 			"name": "LSP-vale-ls",
 			"author": "jdkato",
-			"labels": ["lsp"],
+			"labels": ["lsp", "vale"],
 			"releases": [
 				{
 					"sublime_text": ">=4070",
@@ -844,7 +844,7 @@
 		{
 			"details": "https://github.com/martinbarez/LSP-VHDL-ls",
 			"name": "LSP-VHDL-ls",
-			"labels": ["lsp"],
+			"labels": ["lsp", "vhdl"],
 			"releases": [
 				{
 					"sublime_text": ">=4070",
@@ -889,7 +889,7 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-yaml",
 			"name": "LSP-yaml",
-			"labels": ["lsp"],
+			"labels": ["lsp", "yaml"],
 			"releases": [
 				{
 					"sublime_text": "3154 - 4147",

--- a/repository.json
+++ b/repository.json
@@ -49,6 +49,7 @@
 			],
 			"labels": [
 				"lsp",
+				"intellisense",
 				"auto-complete",
 				"linting",
 				"formatting",

--- a/repository.json
+++ b/repository.json
@@ -46,6 +46,7 @@
 				}
 			],
 			"labels": [
+				"lsp",
 				"auto-complete",
 				"linting",
 				"formatting",

--- a/repository.json
+++ b/repository.json
@@ -24,7 +24,9 @@
 		{
 			"details": "https://github.com/cameroncooper/sublime-chialisp",
 			"name": "Chialisp",
-			"labels": ["lsp"],
+			"labels": [
+				"lsp"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=4000",
@@ -56,7 +58,10 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-angular",
 			"name": "LSP-angular",
-			"labels": ["lsp", "angular"],
+			"labels": [
+				"lsp",
+				"angular"
+			],
 			"releases": [
 				{
 					"sublime_text": "3154 - 3999",
@@ -71,7 +76,10 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-astro",
 			"name": "LSP-astro",
-			"labels": ["lsp", "astro"],
+			"labels": [
+				"lsp",
+				"astro"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=4070",
@@ -82,7 +90,10 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-basedpyright",
 			"name": "LSP-basedpyright",
-			"labels": ["lsp", "python"],
+			"labels": [
+				"lsp",
+				"python"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=4148",
@@ -93,7 +104,10 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-bash",
 			"name": "LSP-bash",
-			"labels": ["lsp", "bash"],
+			"labels": [
+				"lsp",
+				"bash"
+			],
 			"releases": [
 				{
 					"sublime_text": "3154 - 3999",
@@ -108,7 +122,10 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-Bicep",
 			"name": "LSP-Bicep",
-			"labels": ["lsp", "bicep"],
+			"labels": [
+				"lsp",
+				"bicep"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=4070",
@@ -119,7 +136,15 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-biome",
 			"name": "LSP-biome",
-			"labels": ["lsp", "javascript", "typescript", "json", "html", "css", "graphql"],
+			"labels": [
+				"lsp",
+				"javascript",
+				"typescript",
+				"json",
+				"html",
+				"css",
+				"graphql"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=4070",
@@ -130,7 +155,10 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-clangd",
 			"name": "LSP-clangd",
-			"labels": ["lsp", "c++"],
+			"labels": [
+				"lsp",
+				"c++"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=4070",
@@ -145,7 +173,10 @@
 				"TheSecEng",
 				"jfcherng"
 			],
-			"labels": ["lsp", "ai"],
+			"labels": [
+				"lsp",
+				"ai"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=4126",
@@ -170,7 +201,12 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-css",
 			"name": "LSP-css",
-			"labels": ["lsp", "css", "scss", "less"],
+			"labels": [
+				"lsp",
+				"css",
+				"scss",
+				"less"
+			],
 			"releases": [
 				{
 					"sublime_text": "3154 - 4147",
@@ -185,7 +221,10 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-Dart",
 			"name": "LSP-Dart",
-			"labels": ["lsp", "dart"],
+			"labels": [
+				"lsp",
+				"dart"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=4070",
@@ -196,7 +235,11 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-Deno",
 			"name": "LSP-Deno",
-			"labels": ["lsp", "javascript", "typescript"],
+			"labels": [
+				"lsp",
+				"javascript",
+				"typescript"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=4070",
@@ -207,7 +250,10 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-dockerfile",
 			"name": "LSP-dockerfile",
-			"labels": ["lsp", "docker"],
+			"labels": [
+				"lsp",
+				"docker"
+			],
 			"releases": [
 				{
 					"sublime_text": "3154 - 3999",
@@ -222,7 +268,10 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-elixir",
 			"name": "LSP-elixir",
-			"labels": ["lsp", "elixir"],
+			"labels": [
+				"lsp",
+				"elixir"
+			],
 			"releases": [
 				{
 					"sublime_text": "3154 - 3999",
@@ -237,7 +286,10 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-elm",
 			"name": "LSP-elm",
-			"labels": ["lsp", "elm"],
+			"labels": [
+				"lsp",
+				"elm"
+			],
 			"releases": [
 				{
 					"sublime_text": "3154 - 3999",
@@ -252,7 +304,11 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-eslint",
 			"name": "LSP-eslint",
-			"labels": ["lsp", "javascript", "typescript"],
+			"labels": [
+				"lsp",
+				"javascript",
+				"typescript"
+			],
 			"releases": [
 				{
 					"sublime_text": "3154 - 3999",
@@ -267,7 +323,9 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-file-watcher-chokidar",
 			"name": "LSP-file-watcher-chokidar",
-			"labels": ["lsp"],
+			"labels": [
+				"lsp"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=4070",
@@ -278,7 +336,10 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-flow",
 			"name": "LSP-flow",
-			"labels": ["lsp", "flow"],
+			"labels": [
+				"lsp",
+				"flow"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=4070",
@@ -290,7 +351,10 @@
 			"details": "https://github.com/jdkato/LSP-gnols",
 			"name": "LSP-gnols",
 			"author": "jdkato",
-			"labels": ["lsp", "gno"],
+			"labels": [
+				"lsp",
+				"gno"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=4070",
@@ -301,7 +365,10 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-gopls",
 			"name": "LSP-gopls",
-			"labels": ["lsp", "go"],
+			"labels": [
+				"lsp",
+				"go"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=4070",
@@ -326,7 +393,10 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-graphql",
 			"name": "LSP-graphql",
-			"labels": ["lsp", "graphql"],
+			"labels": [
+				"lsp",
+				"graphql"
+			],
 			"releases": [
 				{
 					"sublime_text": "3154 - 3999",
@@ -341,7 +411,10 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-html",
 			"name": "LSP-html",
-			"labels": ["lsp", "html"],
+			"labels": [
+				"lsp",
+				"html"
+			],
 			"releases": [
 				{
 					"sublime_text": "3154 - 4147",
@@ -356,7 +429,10 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-intelephense",
 			"name": "LSP-intelephense",
-			"labels": ["lsp", "php"],
+			"labels": [
+				"lsp",
+				"php"
+			],
 			"releases": [
 				{
 					"sublime_text": "3154 - 3999",
@@ -371,7 +447,10 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-jdtls",
 			"name": "LSP-jdtls",
-			"labels": ["lsp", "java"],
+			"labels": [
+				"lsp",
+				"java"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=4070",
@@ -382,7 +461,10 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-json",
 			"name": "LSP-json",
-			"labels": ["lsp", "json"],
+			"labels": [
+				"lsp",
+				"json"
+			],
 			"releases": [
 				{
 					"sublime_text": "3154 - 4147",
@@ -397,7 +479,10 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-julia",
 			"name": "LSP-julia",
-			"labels": ["lsp", "julia"],
+			"labels": [
+				"lsp",
+				"julia"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=4095",
@@ -423,7 +508,10 @@
 		{
 			"name": "LSP-lemminx",
 			"details": "https://github.com/sublimelsp/LSP-lemminx",
-			"labels": ["lsp", "xml"],
+			"labels": [
+				"lsp",
+				"xml"
+			],
 			"releases": [
 				{
 					"sublime_text": "3154 - 4069",
@@ -464,7 +552,12 @@
 			"details": "https://github.com/sublimelsp/LSP-ltex-ls",
 			"name": "LSP-ltex-ls",
 			"author": "LDAP",
-			"labels": ["lsp", "spellcheck", "latex", "markdown"],
+			"labels": [
+				"lsp",
+				"spellcheck",
+				"latex",
+				"markdown"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=4070",
@@ -475,7 +568,10 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-lua",
 			"name": "LSP-lua",
-			"labels": ["lsp", "lua"],
+			"labels": [
+				"lsp",
+				"lua"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=4070",
@@ -486,7 +582,10 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-marksman",
 			"name": "LSP-marksman",
-			"labels": ["lsp", "markdown"],
+			"labels": [
+				"lsp",
+				"markdown"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=4070",
@@ -497,7 +596,10 @@
 		{
 			"details": "https://github.com/scalameta/metals-sublime",
 			"name": "LSP-metals",
-			"labels": ["lsp", "scala"],
+			"labels": [
+				"lsp",
+				"scala"
+			],
 			"releases": [
 				{
 					"sublime_text": "3154 - 3999",
@@ -512,7 +614,10 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-nimlangserver",
 			"name": "LSP-nimlangserver",
-			"labels": ["lsp", "nim"],
+			"labels": [
+				"lsp",
+				"nim"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=4070",
@@ -523,7 +628,10 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-OmniSharp",
 			"name": "LSP-OmniSharp",
-			"labels": ["lsp", "c#"],
+			"labels": [
+				"lsp",
+				"c#"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=4070",
@@ -534,7 +642,10 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-PowerShellEditorServices",
 			"name": "LSP-PowerShellEditorServices",
-			"labels": ["lsp", "powershell"],
+			"labels": [
+				"lsp",
+				"powershell"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=4070",
@@ -545,7 +656,10 @@
 		{
 			"details": "https://github.com/Sublime-Instincts/LSP-prisma",
 			"name": "LSP-prisma",
-			"labels": ["lsp", "prisma"],
+			"labels": [
+				"lsp",
+				"prisma"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=4126",
@@ -556,7 +670,10 @@
 		{
 			"details": "https://github.com/prometheus-community/sublimelsp-promql",
 			"name": "LSP-promql",
-			"labels": ["lsp", "promql"],
+			"labels": [
+				"lsp",
+				"promql"
+			],
 			"releases": [
 				{
 					"sublime_text": "3154 - 4069",
@@ -567,7 +684,10 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-pylsp",
 			"name": "LSP-pylsp",
-			"labels": ["lsp", "python"],
+			"labels": [
+				"lsp",
+				"python"
+			],
 			"releases": [
 				{
 					"sublime_text": "3154 - 3999",
@@ -582,7 +702,10 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-pyright",
 			"name": "LSP-pyright",
-			"labels": ["lsp", "python"],
+			"labels": [
+				"lsp",
+				"python"
+			],
 			"releases": [
 				{
 					"sublime_text": "3154 - 4147",
@@ -613,7 +736,10 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-R",
 			"name": "LSP-R",
-			"labels": ["lsp", "r"],
+			"labels": [
+				"lsp",
+				"r"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=4070",
@@ -624,7 +750,11 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-rome",
 			"name": "LSP-rome",
-			"labels": ["lsp", "javascript", "typescript"],
+			"labels": [
+				"lsp",
+				"javascript",
+				"typescript"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=4070",
@@ -636,7 +766,10 @@
 			"details": "https://github.com/sublimelsp/LSP-ruff",
 			"name": "LSP-ruff",
 			"author": "LDAP",
-			"labels": ["lsp", "python"],
+			"labels": [
+				"lsp",
+				"python"
+			],
 			"releases": [
 				{
 					"sublime_text": "3154 - 3999",
@@ -651,7 +784,10 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-rust-analyzer",
 			"name": "LSP-rust-analyzer",
-			"labels": ["lsp", "rust"],
+			"labels": [
+				"lsp",
+				"rust"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=4070",
@@ -662,7 +798,10 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-serenata",
 			"name": "LSP-serenata",
-			"labels": ["lsp", "php"],
+			"labels": [
+				"lsp",
+				"php"
+			],
 			"releases": [
 				{
 					"sublime_text": "3154 - 3999",
@@ -673,7 +812,11 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-some-sass",
 			"name": "LSP-some-sass",
-			"labels": ["lsp", "scss", "sass"],
+			"labels": [
+				"lsp",
+				"scss",
+				"sass"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=4169",
@@ -684,7 +827,14 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-SourceKit",
 			"name": "LSP-SourceKit",
-			"labels": ["lsp", "c", "c++", "objective-c", "objective-c++", "swift"],
+			"labels": [
+				"lsp",
+				"c",
+				"c++",
+				"objective-c",
+				"objective-c++",
+				"swift"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=4070",
@@ -699,7 +849,12 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-stylelint",
 			"name": "LSP-stylelint",
-			"labels": ["lsp", "css", "scss", "less"],
+			"labels": [
+				"lsp",
+				"css",
+				"scss",
+				"less"
+			],
 			"releases": [
 				{
 					"sublime_text": "3154 - 3999",
@@ -714,7 +869,10 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-svelte",
 			"name": "LSP-svelte",
-			"labels": ["lsp", "svelte"],
+			"labels": [
+				"lsp",
+				"svelte"
+			],
 			"releases": [
 				{
 					"sublime_text": "3154 - 3999",
@@ -729,7 +887,10 @@
 		{
 			"details": "https://github.com/HuygensING/LSP-tagml",
 			"name": "LSP-tagml",
-			"labels": ["lsp", "tagml"],
+			"labels": [
+				"lsp",
+				"tagml"
+			],
 			"releases": [
 				{
 					"sublime_text": "3154 - 4069",
@@ -740,7 +901,9 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-tailwindcss",
 			"name": "LSP-tailwindcss",
-			"labels": ["lsp"],
+			"labels": [
+				"lsp"
+			],
 			"releases": [
 				{
 					"sublime_text": "3154 - 3999",
@@ -755,7 +918,10 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-taplo",
 			"name": "LSP-taplo",
-			"labels": ["lsp", "toml"],
+			"labels": [
+				"lsp",
+				"toml"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=4070",
@@ -769,7 +935,10 @@
 			"previous_names": [
 				"LSP-Terraform"
 			],
-			"labels": ["lsp", "terraform"],
+			"labels": [
+				"lsp",
+				"terraform"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=4070",
@@ -780,7 +949,10 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-TexLab",
 			"name": "LSP-TexLab",
-			"labels": ["lsp", "latex"],
+			"labels": [
+				"lsp",
+				"latex"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=4070",
@@ -791,7 +963,11 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-typescript",
 			"name": "LSP-typescript",
-			"labels": ["lsp", "javascript", "typescript"],
+			"labels": [
+				"lsp",
+				"javascript",
+				"typescript"
+			],
 			"releases": [
 				{
 					"sublime_text": "3154 - 3999",
@@ -806,7 +982,11 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-twiggy",
 			"name": "LSP-twiggy",
-			"labels": ["lsp", "php", "twig"],
+			"labels": [
+				"lsp",
+				"php",
+				"twig"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=4169",
@@ -818,7 +998,10 @@
 			"details": "https://github.com/errata-ai/LSP-vale-ls",
 			"name": "LSP-vale-ls",
 			"author": "jdkato",
-			"labels": ["lsp", "vale"],
+			"labels": [
+				"lsp",
+				"vale"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=4070",
@@ -829,7 +1012,10 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-vetur",
 			"name": "LSP-vetur",
-			"labels": ["lsp", "vue"],
+			"labels": [
+				"lsp",
+				"vue"
+			],
 			"releases": [
 				{
 					"sublime_text": "3154 - 3999",
@@ -844,7 +1030,10 @@
 		{
 			"details": "https://github.com/martinbarez/LSP-VHDL-ls",
 			"name": "LSP-VHDL-ls",
-			"labels": ["lsp", "vhdl"],
+			"labels": [
+				"lsp",
+				"vhdl"
+			],
 			"releases": [
 				{
 					"sublime_text": ">=4070",
@@ -859,7 +1048,10 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-volar",
 			"name": "LSP-volar",
-			"labels": ["lsp", "vue"],
+			"labels": [
+				"lsp",
+				"vue"
+			],
 			"releases": [
 				{
 					"sublime_text": "3154 - 4147",
@@ -874,7 +1066,10 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-vue",
 			"name": "LSP-vue",
-			"labels": ["lsp", "vue"],
+			"labels": [
+				"lsp",
+				"vue"
+			],
 			"releases": [
 				{
 					"sublime_text": "3154 - 3999",
@@ -889,7 +1084,10 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-yaml",
 			"name": "LSP-yaml",
-			"labels": ["lsp", "yaml"],
+			"labels": [
+				"lsp",
+				"yaml"
+			],
 			"releases": [
 				{
 					"sublime_text": "3154 - 4147",

--- a/repository.json
+++ b/repository.json
@@ -24,13 +24,7 @@
 		{
 			"details": "https://github.com/cameroncooper/sublime-chialisp",
 			"name": "Chialisp",
-			"labels": [
-				"auto-complete",
-				"linting",
-				"formatting",
-				"code navigation",
-				"intellisense"
-			],
+			"labels": ["lsp"],
 			"releases": [
 				{
 					"sublime_text": ">=4000",
@@ -55,50 +49,13 @@
 				"auto-complete",
 				"linting",
 				"formatting",
-				"code navigation",
-				"intellisense",
-				"javascript",
-				"typescript",
-				"php",
-				"python",
-				"snippets",
-				"ruby",
-				"r",
-				"java",
-				"go",
-				"golang",
-				"bash",
-				"kotlin",
-				"html",
-				"css",
-				"ocaml",
-				"rust",
-				"julia",
-				"lua",
-				"haskell",
-				"c",
-				"cpp",
-				"c++",
-				"csharp",
-				"c#",
-				"react",
-				"swift",
-				"objective-c",
-				"objectivec",
-				"method completion",
-				"intellicode"
+				"code navigation"
 			]
 		},
 		{
 			"details": "https://github.com/sublimelsp/LSP-angular",
 			"name": "LSP-angular",
-			"labels": [
-				"auto-complete",
-				"linting",
-				"formatting",
-				"code navigation",
-				"intellisense"
-			],
+			"labels": ["lsp"],
 			"releases": [
 				{
 					"sublime_text": "3154 - 3999",
@@ -113,12 +70,7 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-astro",
 			"name": "LSP-astro",
-			"labels": [
-				"auto-complete",
-				"linting",
-				"code navigation",
-				"intellisense"
-			],
+			"labels": ["lsp"],
 			"releases": [
 				{
 					"sublime_text": ">=4070",
@@ -129,13 +81,7 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-basedpyright",
 			"name": "LSP-basedpyright",
-			"labels": [
-				"auto-complete",
-				"linting",
-				"formatting",
-				"code navigation",
-				"intellisense"
-			],
+			"labels": ["lsp", "python"],
 			"releases": [
 				{
 					"sublime_text": ">=4148",
@@ -146,13 +92,7 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-bash",
 			"name": "LSP-bash",
-			"labels": [
-				"auto-complete",
-				"linting",
-				"formatting",
-				"code navigation",
-				"intellisense"
-			],
+			"labels": ["lsp"],
 			"releases": [
 				{
 					"sublime_text": "3154 - 3999",
@@ -167,13 +107,7 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-Bicep",
 			"name": "LSP-Bicep",
-			"labels": [
-				"auto-complete",
-				"linting",
-				"formatting",
-				"code navigation",
-				"intellisense"
-			],
+			"labels": ["lsp"],
 			"releases": [
 				{
 					"sublime_text": ">=4070",
@@ -184,6 +118,7 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-biome",
 			"name": "LSP-biome",
+			"labels": ["lsp"],
 			"releases": [
 				{
 					"sublime_text": ">=4070",
@@ -194,13 +129,7 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-clangd",
 			"name": "LSP-clangd",
-			"labels": [
-				"auto-complete",
-				"linting",
-				"formatting",
-				"code navigation",
-				"intellisense"
-			],
+			"labels": ["lsp", "c++"],
 			"releases": [
 				{
 					"sublime_text": ">=4070",
@@ -215,11 +144,7 @@
 				"TheSecEng",
 				"jfcherng"
 			],
-			"labels": [
-				"auto-complete",
-				"code-intelligence",
-				"intellisense"
-			],
+			"labels": ["lsp"],
 			"releases": [
 				{
 					"sublime_text": ">=4126",
@@ -231,9 +156,8 @@
 			"details": "https://github.com/sublimelsp/LSP-cspell",
 			"name": "LSP-cspell",
 			"labels": [
-				"linting",
-				"cspell",
-				"spell"
+				"lsp",
+				"spellcheck"
 			],
 			"releases": [
 				{
@@ -245,13 +169,7 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-css",
 			"name": "LSP-css",
-			"labels": [
-				"auto-complete",
-				"linting",
-				"formatting",
-				"code navigation",
-				"intellisense"
-			],
+			"labels": ["lsp", "css", "scss", "less"],
 			"releases": [
 				{
 					"sublime_text": "3154 - 4147",
@@ -266,13 +184,7 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-Dart",
 			"name": "LSP-Dart",
-			"labels": [
-				"auto-complete",
-				"linting",
-				"formatting",
-				"code navigation",
-				"intellisense"
-			],
+			"labels": ["lsp"],
 			"releases": [
 				{
 					"sublime_text": ">=4070",
@@ -283,13 +195,7 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-Deno",
 			"name": "LSP-Deno",
-			"labels": [
-				"auto-complete",
-				"linting",
-				"formatting",
-				"code navigation",
-				"intellisense"
-			],
+			"labels": ["lsp", "javascript", "jsx", "typescript", "tsx"],
 			"releases": [
 				{
 					"sublime_text": ">=4070",
@@ -300,13 +206,7 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-dockerfile",
 			"name": "LSP-dockerfile",
-			"labels": [
-				"auto-complete",
-				"linting",
-				"formatting",
-				"code navigation",
-				"intellisense"
-			],
+			"labels": ["lsp"],
 			"releases": [
 				{
 					"sublime_text": "3154 - 3999",
@@ -321,13 +221,7 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-elixir",
 			"name": "LSP-elixir",
-			"labels": [
-				"auto-complete",
-				"linting",
-				"formatting",
-				"code navigation",
-				"intellisense"
-			],
+			"labels": ["lsp"],
 			"releases": [
 				{
 					"sublime_text": "3154 - 3999",
@@ -342,13 +236,7 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-elm",
 			"name": "LSP-elm",
-			"labels": [
-				"auto-complete",
-				"linting",
-				"formatting",
-				"code navigation",
-				"intellisense"
-			],
+			"labels": ["lsp"],
 			"releases": [
 				{
 					"sublime_text": "3154 - 3999",
@@ -363,9 +251,7 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-eslint",
 			"name": "LSP-eslint",
-			"labels": [
-				"linting"
-			],
+			"labels": ["lsp", "javascript", "jsx", "typescript", "tsx"],
 			"releases": [
 				{
 					"sublime_text": "3154 - 3999",
@@ -380,6 +266,7 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-file-watcher-chokidar",
 			"name": "LSP-file-watcher-chokidar",
+			"labels": ["lsp"],
 			"releases": [
 				{
 					"sublime_text": ">=4070",
@@ -390,6 +277,7 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-flow",
 			"name": "LSP-flow",
+			"labels": ["lsp", "javascript"],
 			"releases": [
 				{
 					"sublime_text": ">=4070",
@@ -401,11 +289,7 @@
 			"details": "https://github.com/jdkato/LSP-gnols",
 			"name": "LSP-gnols",
 			"author": "jdkato",
-			"labels": [
-				"auto-complete",
-				"linting",
-				"intellisense"
-			],
+			"labels": ["lsp"],
 			"releases": [
 				{
 					"sublime_text": ">=4070",
@@ -416,13 +300,7 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-gopls",
 			"name": "LSP-gopls",
-			"labels": [
-				"auto-complete",
-				"linting",
-				"formatting",
-				"code navigation",
-				"intellisense"
-			],
+			"labels": ["lsp", "go"],
 			"releases": [
 				{
 					"sublime_text": ">=4070",
@@ -434,7 +312,8 @@
 			"details": "https://github.com/sublimelsp/LSP-Grammarly",
 			"name": "LSP-Grammarly",
 			"labels": [
-				"linting"
+				"lsp",
+				"spellcheck"
 			],
 			"releases": [
 				{
@@ -446,13 +325,7 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-graphql",
 			"name": "LSP-graphql",
-			"labels": [
-				"auto-complete",
-				"linting",
-				"formatting",
-				"code navigation",
-				"intellisense"
-			],
+			"labels": ["lsp"],
 			"releases": [
 				{
 					"sublime_text": "3154 - 3999",
@@ -467,13 +340,7 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-html",
 			"name": "LSP-html",
-			"labels": [
-				"auto-complete",
-				"linting",
-				"formatting",
-				"code navigation",
-				"intellisense"
-			],
+			"labels": ["lsp"],
 			"releases": [
 				{
 					"sublime_text": "3154 - 4147",
@@ -488,13 +355,7 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-intelephense",
 			"name": "LSP-intelephense",
-			"labels": [
-				"auto-complete",
-				"linting",
-				"formatting",
-				"code navigation",
-				"intellisense"
-			],
+			"labels": ["lsp", "php"],
 			"releases": [
 				{
 					"sublime_text": "3154 - 3999",
@@ -509,13 +370,7 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-jdtls",
 			"name": "LSP-jdtls",
-			"labels": [
-				"auto-complete",
-				"linting",
-				"formatting",
-				"code navigation",
-				"intellisense"
-			],
+			"labels": ["lsp", "java"],
 			"releases": [
 				{
 					"sublime_text": ">=4070",
@@ -526,13 +381,7 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-json",
 			"name": "LSP-json",
-			"labels": [
-				"auto-complete",
-				"linting",
-				"formatting",
-				"code navigation",
-				"intellisense"
-			],
+			"labels": ["lsp"],
 			"releases": [
 				{
 					"sublime_text": "3154 - 4147",
@@ -547,14 +396,7 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-julia",
 			"name": "LSP-julia",
-			"labels": [
-				"julia",
-				"auto-complete",
-				"linting",
-				"formatting",
-				"code navigation",
-				"intellisense"
-			],
+			"labels": ["lsp"],
 			"releases": [
 				{
 					"sublime_text": ">=4095",
@@ -566,13 +408,9 @@
 			"details": "https://github.com/sublimelsp/LSP-kotlin",
 			"name": "LSP-kotlin",
 			"labels": [
+				"lsp",
 				"java",
-				"kotlin",
-				"auto-complete",
-				"linting",
-				"formatting",
-				"code navigation",
-				"intellisense"
+				"kotlin"
 			],
 			"releases": [
 				{
@@ -584,13 +422,7 @@
 		{
 			"name": "LSP-lemminx",
 			"details": "https://github.com/sublimelsp/LSP-lemminx",
-			"labels": [
-				"auto-complete",
-				"linting",
-				"formatting",
-				"code navigation",
-				"intellisense"
-			],
+			"labels": ["lsp"],
 			"releases": [
 				{
 					"sublime_text": "3154 - 4069",
@@ -612,12 +444,9 @@
 			"homepage": "https://developer.aleo.org/overview/",
 			"issues": "https://github.com/AleoHQ/leo-plugins/issues",
 			"labels": [
+				"lsp",
 				"aleo",
 				"leo",
-				"auto-complete",
-				"linting",
-				"code navigation",
-				"intellisense",
 				"color scheme",
 				"language syntax",
 				"snippets",
@@ -634,6 +463,7 @@
 			"details": "https://github.com/sublimelsp/LSP-ltex-ls",
 			"name": "LSP-ltex-ls",
 			"author": "LDAP",
+			"labels": ["lsp", "spellcheck", "latex", "markdown"],
 			"releases": [
 				{
 					"sublime_text": ">=4070",
@@ -644,6 +474,7 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-lua",
 			"name": "LSP-lua",
+			"labels": ["lsp"],
 			"releases": [
 				{
 					"sublime_text": ">=4070",
@@ -654,6 +485,7 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-marksman",
 			"name": "LSP-marksman",
+			"labels": ["lsp", "markdown"],
 			"releases": [
 				{
 					"sublime_text": ">=4070",
@@ -664,13 +496,7 @@
 		{
 			"details": "https://github.com/scalameta/metals-sublime",
 			"name": "LSP-metals",
-			"labels": [
-				"auto-complete",
-				"linting",
-				"formatting",
-				"code navigation",
-				"intellisense"
-			],
+			"labels": ["lsp"],
 			"releases": [
 				{
 					"sublime_text": "3154 - 3999",
@@ -685,13 +511,7 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-nimlangserver",
 			"name": "LSP-nimlangserver",
-			"labels": [
-				"auto-complete",
-				"linting",
-				"formatting",
-				"code navigation",
-				"intellisense"
-			],
+			"labels": ["lsp"],
 			"releases": [
 				{
 					"sublime_text": ">=4070",
@@ -702,13 +522,7 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-OmniSharp",
 			"name": "LSP-OmniSharp",
-			"labels": [
-				"auto-complete",
-				"linting",
-				"formatting",
-				"code navigation",
-				"intellisense"
-			],
+			"labels": ["lsp", "c#"],
 			"releases": [
 				{
 					"sublime_text": ">=4070",
@@ -719,6 +533,7 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-PowerShellEditorServices",
 			"name": "LSP-PowerShellEditorServices",
+			"labels": ["lsp"],
 			"releases": [
 				{
 					"sublime_text": ">=4070",
@@ -729,13 +544,7 @@
 		{
 			"details": "https://github.com/Sublime-Instincts/LSP-prisma",
 			"name": "LSP-prisma",
-			"labels": [
-				"auto-complete",
-				"linting",
-				"formatting",
-				"code navigation",
-				"intellisense"
-			],
+			"labels": ["lsp"],
 			"releases": [
 				{
 					"sublime_text": ">=4126",
@@ -746,13 +555,7 @@
 		{
 			"details": "https://github.com/prometheus-community/sublimelsp-promql",
 			"name": "LSP-promql",
-			"labels": [
-				"auto-complete",
-				"linting",
-				"formatting",
-				"code navigation",
-				"intellisense"
-			],
+			"labels": ["lsp"],
 			"releases": [
 				{
 					"sublime_text": "3154 - 4069",
@@ -763,6 +566,7 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-pylsp",
 			"name": "LSP-pylsp",
+			"labels": ["lsp", "python"],
 			"releases": [
 				{
 					"sublime_text": "3154 - 3999",
@@ -777,13 +581,7 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-pyright",
 			"name": "LSP-pyright",
-			"labels": [
-				"auto-complete",
-				"linting",
-				"formatting",
-				"code navigation",
-				"intellisense"
-			],
+			"labels": ["lsp", "python"],
 			"releases": [
 				{
 					"sublime_text": "3154 - 4147",
@@ -800,6 +598,7 @@
 			"name": "LSP-pyvoice",
 			"author": "mpourmpoulis",
 			"labels": [
+				"lsp",
 				"voice coding",
 				"accessibility"
 			],
@@ -813,6 +612,7 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-R",
 			"name": "LSP-R",
+			"labels": ["lsp"],
 			"releases": [
 				{
 					"sublime_text": ">=4070",
@@ -823,6 +623,7 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-rome",
 			"name": "LSP-rome",
+			"labels": ["lsp"],
 			"releases": [
 				{
 					"sublime_text": ">=4070",
@@ -834,6 +635,7 @@
 			"details": "https://github.com/sublimelsp/LSP-ruff",
 			"name": "LSP-ruff",
 			"author": "LDAP",
+			"labels": ["lsp"],
 			"releases": [
 				{
 					"sublime_text": "3154 - 3999",
@@ -848,13 +650,7 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-rust-analyzer",
 			"name": "LSP-rust-analyzer",
-			"labels": [
-				"auto-complete",
-				"linting",
-				"formatting",
-				"code navigation",
-				"intellisense"
-			],
+			"labels": ["lsp"],
 			"releases": [
 				{
 					"sublime_text": ">=4070",
@@ -865,13 +661,7 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-serenata",
 			"name": "LSP-serenata",
-			"labels": [
-				"auto-complete",
-				"linting",
-				"formatting",
-				"code navigation",
-				"intellisense"
-			],
+			"labels": ["lsp", "php"],
 			"releases": [
 				{
 					"sublime_text": "3154 - 3999",
@@ -882,13 +672,7 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-some-sass",
 			"name": "LSP-some-sass",
-			"labels": [
-				"auto-complete",
-				"linting",
-				"formatting",
-				"code navigation",
-				"intellisense"
-			],
+			"labels": ["lsp", "scss", "sass"],
 			"releases": [
 				{
 					"sublime_text": ">=4169",
@@ -899,6 +683,7 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-SourceKit",
 			"name": "LSP-SourceKit",
+			"labels": ["lsp", "c", "c++", "objective-c", "objective-c++", "swift"],
 			"releases": [
 				{
 					"sublime_text": ">=4070",
@@ -913,9 +698,7 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-stylelint",
 			"name": "LSP-stylelint",
-			"labels": [
-				"linting"
-			],
+			"labels": ["lsp"],
 			"releases": [
 				{
 					"sublime_text": "3154 - 3999",
@@ -930,13 +713,7 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-svelte",
 			"name": "LSP-svelte",
-			"labels": [
-				"auto-complete",
-				"linting",
-				"formatting",
-				"code navigation",
-				"intellisense"
-			],
+			"labels": ["lsp"],
 			"releases": [
 				{
 					"sublime_text": "3154 - 3999",
@@ -951,13 +728,7 @@
 		{
 			"details": "https://github.com/HuygensING/LSP-tagml",
 			"name": "LSP-tagml",
-			"labels": [
-				"auto-complete",
-				"linting",
-				"formatting",
-				"code navigation",
-				"intellisense"
-			],
+			"labels": ["lsp"],
 			"releases": [
 				{
 					"sublime_text": "3154 - 4069",
@@ -968,10 +739,7 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-tailwindcss",
 			"name": "LSP-tailwindcss",
-			"labels": [
-				"auto-complete",
-				"intellisense"
-			],
+			"labels": ["lsp"],
 			"releases": [
 				{
 					"sublime_text": "3154 - 3999",
@@ -986,12 +754,7 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-taplo",
 			"name": "LSP-taplo",
-			"labels": [
-				"auto-complete",
-				"linting",
-				"formatting",
-				"intellisense"
-			],
+			"labels": ["lsp"],
 			"releases": [
 				{
 					"sublime_text": ">=4070",
@@ -1005,13 +768,7 @@
 			"previous_names": [
 				"LSP-Terraform"
 			],
-			"labels": [
-				"auto-complete",
-				"linting",
-				"formatting",
-				"code navigation",
-				"intellisense"
-			],
+			"labels": ["lsp"],
 			"releases": [
 				{
 					"sublime_text": ">=4070",
@@ -1022,13 +779,7 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-TexLab",
 			"name": "LSP-TexLab",
-			"labels": [
-				"auto-complete",
-				"linting",
-				"formatting",
-				"code navigation",
-				"intellisense"
-			],
+			"labels": ["lsp", "latex"],
 			"releases": [
 				{
 					"sublime_text": ">=4070",
@@ -1039,13 +790,7 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-typescript",
 			"name": "LSP-typescript",
-			"labels": [
-				"auto-complete",
-				"linting",
-				"formatting",
-				"code navigation",
-				"intellisense"
-			],
+			"labels": ["lsp", "javascript", "jsx", "typescript", "tsx"],
 			"releases": [
 				{
 					"sublime_text": "3154 - 3999",
@@ -1060,13 +805,7 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-twiggy",
 			"name": "LSP-twiggy",
-			"labels": [
-				"auto-complete",
-				"linting",
-				"formatting",
-				"code navigation",
-				"intellisense"
-			],
+			"labels": ["lsp", "php", "twig"],
 			"releases": [
 				{
 					"sublime_text": ">=4169",
@@ -1078,11 +817,7 @@
 			"details": "https://github.com/errata-ai/LSP-vale-ls",
 			"name": "LSP-vale-ls",
 			"author": "jdkato",
-			"labels": [
-				"auto-complete",
-				"linting",
-				"intellisense"
-			],
+			"labels": ["lsp"],
 			"releases": [
 				{
 					"sublime_text": ">=4070",
@@ -1093,13 +828,7 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-vetur",
 			"name": "LSP-vetur",
-			"labels": [
-				"auto-complete",
-				"linting",
-				"formatting",
-				"code navigation",
-				"intellisense"
-			],
+			"labels": ["lsp", "vue"],
 			"releases": [
 				{
 					"sublime_text": "3154 - 3999",
@@ -1114,9 +843,7 @@
 		{
 			"details": "https://github.com/martinbarez/LSP-VHDL-ls",
 			"name": "LSP-VHDL-ls",
-			"labels": [
-				"VHDL"
-			],
+			"labels": ["lsp"],
 			"releases": [
 				{
 					"sublime_text": ">=4070",
@@ -1131,13 +858,7 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-volar",
 			"name": "LSP-volar",
-			"labels": [
-				"auto-complete",
-				"linting",
-				"formatting",
-				"code navigation",
-				"intellisense"
-			],
+			"labels": ["lsp", "vue"],
 			"releases": [
 				{
 					"sublime_text": "3154 - 4147",
@@ -1152,13 +873,7 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-vue",
 			"name": "LSP-vue",
-			"labels": [
-				"auto-complete",
-				"linting",
-				"formatting",
-				"code navigation",
-				"intellisense"
-			],
+			"labels": ["lsp", "vue"],
 			"releases": [
 				{
 					"sublime_text": "3154 - 3999",
@@ -1173,13 +888,7 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-yaml",
 			"name": "LSP-yaml",
-			"labels": [
-				"auto-complete",
-				"linting",
-				"formatting",
-				"code navigation",
-				"intellisense"
-			],
+			"labels": ["lsp"],
 			"releases": [
 				{
 					"sublime_text": "3154 - 4147",

--- a/repository.json
+++ b/repository.json
@@ -277,7 +277,7 @@
 		{
 			"details": "https://github.com/sublimelsp/LSP-flow",
 			"name": "LSP-flow",
-			"labels": ["lsp", "javascript"],
+			"labels": ["lsp"],
 			"releases": [
 				{
 					"sublime_text": ">=4070",


### PR DESCRIPTION
If you visit https://packages.sublimetext.io/?q=lsp&sort=installed
You will notice that LSP has a lot of labels.

There was some discussion on Discord to reduce the number of tags on LSP,
and to add a `lsp` label for LSP-* packages.

I did agree with this, so thus I created this PR.

<img height="350" alt="Screenshot 2025-08-22 at 21 00 41" src="https://github.com/user-attachments/assets/dd01fd16-9c6e-47d9-9ba1-824b50ca6d4f" />