### PR TITLE
Add LSP-Tinymist

### DIFF
--- a/repository.json
+++ b/repository.json
@@ -962,6 +962,20 @@
 			]
 		},
 		{
+			"details": "https://github.com/sublimelsp/LSP-Tinymist",
+			"name": "LSP-Tinymist",
+			"labels": [
+				"lsp",
+				"typst"
+			],
+			"releases": [
+				{
+					"sublime_text": ">=4132",
+					"tags": true
+				}
+			]
+		},
+		{
 			"details": "https://github.com/sublimelsp/LSP-typescript",
 			"name": "LSP-typescript",
 			"labels": [


### PR DESCRIPTION
The package downloads and unzips the language server executable from GitHub releases of the upstream repository. I used a download script copied from LSP-TexLab for that.

I can confirm that it works on Windows, but I have not tested on Linux or macOS.