### PR TITLE
Remove non-working and not maintained chialsp

### DIFF
--- a/repository.json
+++ b/repository.json
@@ -22,19 +22,6 @@
 	],
 	"packages": [
 		{
-			"details": "https://github.com/cameroncooper/sublime-chialisp",
-			"name": "Chialisp",
-			"labels": [
-				"lsp"
-			],
-			"releases": [
-				{
-					"sublime_text": ">=4000",
-					"tags": true
-				}
-			]
-		},
-		{
 			"details": "https://github.com/sublimelsp/LSP",
 			"name": "LSP",
 			"releases": [


### PR DESCRIPTION
This package was not updated to use 3.8 host so it's not functional and the [attempt at fixing it](https://github.com/cameroncooper/sublime-chialisp/pull/3) had no response so removing.