### PR TITLE
Take over LSP-prisma

### DIFF
--- a/repository.json
+++ b/repository.json
@@ -733,7 +733,7 @@
 			]
 		},
 		{
-			"details": "https://github.com/Sublime-Instincts/LSP-prisma",
+			"details": "https://github.com/sublimelsp/LSP-prisma",
 			"name": "LSP-prisma",
 			"labels": [
 				"lsp",


### PR DESCRIPTION
Author of LSP-prisma (@UltraInstinct05) has not been active for few years now.

https://github.com/Sublime-Instincts/LSP-prisma/pull/61 had no response for few months and there is no github activity on https://github.com/UltraInstinct05

Thus we should take over the package so that we can maintain it. I have already updated our copy with latest server version, migrated to LspPlugin and other goodies.