### PR TITLE
Add LSP-vibescript

### DIFF
--- a/repository.json
+++ b/repository.json
@@ -1194,6 +1194,20 @@
 			]
 		},
 		{
+			"details": "https://github.com/mgomes/LSP-vibescript",
+			"labels": [
+				"lsp",
+				"vibescript"
+			],
+			"name": "LSP-vibescript",
+			"releases": [
+				{
+					"sublime_text": ">=4107",
+					"tags": true
+				}
+			]
+		},
+		{
 			"details": "https://github.com/sublimelsp/LSP-volar",
 			"name": "LSP-volar",
 			"labels": [


### PR DESCRIPTION
Adds [LSP-vibescript](https://github.com/mgomes/LSP-vibescript), the helper for the [Vibescript](https://github.com/mgomes/vibescript) language server (`vibes lsp`): diagnostics, hover documentation, and completions for `.vibe` files.

Built on the new `LspPlugin` class, split out of the Vibescript syntax package per review feedback on sublimehq/package_control_channel#9483.