### PR TITLE
chore: allow unsafe pr checkout

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -12,6 +12,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: refs/pull/${{ github.event.pull_request.number }}/merge
+          allow-unsafe-pr-checkout: true
 
       # Ensures python3-setuptools is installed
       - name: Setup Python


### PR DESCRIPTION
Needed for running ST review bots for forks that open PRs.

Since actions/checkout@v7. See: https://docs.github.com/en/actions/reference/security/securely-using-pull_request_target