### PR TITLE
Add LSP-carve

### DIFF
--- a/repository.json
+++ b/repository.json
@@ -156,6 +156,21 @@
 			]
 		},
 		{
+			"details": "https://github.com/markup-carve/sublime-carve-lsp",
+			"name": "LSP-carve",
+			"labels": [
+				"lsp",
+				"carve",
+				"markup"
+			],
+			"releases": [
+				{
+					"sublime_text": ">=4000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"details": "https://github.com/sublimelsp/LSP-clangd",
 			"name": "LSP-clangd",
 			"labels": [


### PR DESCRIPTION
Adds **LSP-carve**, a language server helper package for Carve, a Markdown-like markup language (`.crv`).

- Package: https://github.com/markup-carve/sublime-carve-lsp
- Tagged `0.1.0`; ST4 only (depends on `lsp_utils` and `sublime_lib`).
- Provides diagnostics, hover and document symbols via the Carve language server.

This was first opened against the main channel (sublimehq/package_control_channel), where rchl kindly pointed out that LSP-* helper packages belong here instead. That PR is being closed in favour of this one.