### PR TITLE
Add LSP-syntect and LSP-pyrefly

### DIFF
--- a/repository.json
+++ b/repository.json
@@ -839,6 +839,20 @@
 			]
 		},
 		{
+			"details": "https://gitlab.com/doering-ai-sublime/lsp-pyrefly",
+			"name": "LSP-pyrefly",
+			"labels": [
+				"lsp",
+				"python"
+			],
+			"releases": [
+				{
+					"sublime_text": ">=4000",
+					"tags": true
+				}
+			]
+		},
+		{
 			"details": "https://github.com/sublimelsp/LSP-pyright",
 			"name": "LSP-pyright",
 			"labels": [
@@ -998,6 +1012,19 @@
 					"sublime_text": "3154 - 3999",
 					"tags": "st3-"
 				},
+				{
+					"sublime_text": ">=4000",
+					"tags": true
+				}
+			]
+		},
+		{
+			"details": "https://gitlab.com/doering-ai-sublime/lsp-syntax",
+			"name": "LSP-syntect",
+			"labels": [
+				"lsp"
+			],
+			"releases": [
 				{
 					"sublime_text": ">=4000",
 					"tags": true


### PR DESCRIPTION
Adds two unconnected server adapters, both authored/maintained by me, hosted on public GitLab repos with `v0.7.0` semver tags and `.gitattributes` export-ignore.

| Name | What it is |
| --- | --- |
| LSP-syntect | LSP for plain-text and generic files: uses Sublime's own syntect/sublime-syntax highlighting pipeline behind an LSP-compatible server to bring language-server features (diagnostics surface, symbols) to files no dedicated server covers. |
| LSP-pyrefly | LSP integration for [pyrefly](https://pyrefly.org), Meta's Rust-based Python type checker — server launch (**via `uv` -> py313 venv, like `LSP-ruff`**), settings schema, and command-palette commands included.  |

With this addition, I think we cover all four main type checkers in the ecosystem (`mypy` via `pythonlsp` (? it's been a while), `LSP-ty`, `LSP-pyright`, and `LSP-basedpyright`). I have embarrassingly enough tried them all over the years, and tried to achieve consistency of approach with them in these new ones.

Both ship settings opened via `edit_settings` (split view), no context-menu entries, and no key bindings.

EDIT: Including an explainer & AI statement from some simultaneous PRs in the main Package Control repo. 

> And to answer the obvious question a bit early: no, I would not describe any of these packages (in this pull request or its sibling) as in any way vibe-coded. The quickest explanation is just to look at my GitLab contributions to these repos, which are years of slow iteration, ~12mo of more dedicated, gradually-increasing-in-scope work, and then a sprint starting ~July 1st using closely-orchestrated & bounded fleets of agents to polish my "pile of shame" ([so-to-speak](https://www.reddit.com/media?url=https%253A%252F%252Fpreview.redd.it%252Fpile-of-shame-v0-6frf5f3b33be1.jpeg%253Fauto%253Dwebp%2526s%253Dc9ce275b9a819f15879e726ab8581a4d)). I stand by everything in these repos 100% as my own work / responsibility.

**The Syntect package is obviously quite experimental by its very nature**, but the Pyrefly package has been used daily across a variety of repos, python versions, reinstalls, etc., with a steady stream of fixes to accompany all of that. It's quite stable now and I don't see myself ever going back -- please let me know if it could/should be better, though! 