### PR TITLE
Add LSP-Laravel

### DIFF
--- a/repository.json
+++ b/repository.json
@@ -594,13 +594,6 @@
 			],
 			"releases": [
 				{
-					"platforms": [
-						"linux-arm64",
-						"linux-x64",
-						"osx-arm64",
-						"osx-x64",
-						"windows-x64"
-					],
 					"sublime_text": ">=4132",
 					"tags": true
 				}

--- a/repository.json
+++ b/repository.json
@@ -585,6 +585,28 @@
 			]
 		},
 		{
+			"details": "https://github.com/laravel/sublime-extension",
+			"name": "LSP-Laravel",
+			"labels": [
+				"lsp",
+				"php",
+				"laravel"
+			],
+			"releases": [
+				{
+					"platforms": [
+						"linux-arm64",
+						"linux-x64",
+						"osx-arm64",
+						"osx-x64",
+						"windows-x64"
+					],
+					"sublime_text": ">=4132",
+					"tags": true
+				}
+			]
+		},
+		{
 			"details": "https://github.com/sublimelsp/LSP-kotlin",
 			"name": "LSP-kotlin",
 			"labels": [


### PR DESCRIPTION
Adds the official `LSP-Laravel` package to the Package Control registry. It integrates the official [Laravel LSP](https://github.com/laravel/lsp) with Sublime Text and automatically downloads and manages the appropriate server binary for each supported platform.