### PR TITLE
Add LSP-MaaFramework

### DIFF
--- a/repository.json
+++ b/repository.json
@@ -730,11 +730,8 @@
 			],
 			"releases": [
 				{
-					"url": "https://github.com/Windsland52/maa-support-sublime/releases/download/v0.3.0/LSP-MaaFramework.sublime-package",
-					"platforms": "*",
-					"date": "2026-08-08 15:37:30",
-					"version": "0.3.0",
-					"sublime_text": ">=4000"
+					"sublime_text": ">=4000",
+					"tags": "sublime-v"
 				}
 			]
 		},

--- a/repository.json
+++ b/repository.json
@@ -720,6 +720,25 @@
 			]
 		},
 		{
+			"details": "https://github.com/Windsland52/maa-support-sublime",
+			"name": "LSP-MaaFramework",
+			"labels": [
+				"lsp",
+				"json",
+				"linting",
+				"code navigation"
+			],
+			"releases": [
+				{
+					"url": "https://github.com/Windsland52/maa-support-sublime/releases/download/v0.3.0/LSP-MaaFramework.sublime-package",
+					"platforms": "*",
+					"date": "2026-08-08 15:37:30",
+					"version": "0.3.0",
+					"sublime_text": ">=4000"
+				}
+			]
+		},
+		{
 			"details": "https://github.com/sublimelsp/LSP-marksman",
 			"name": "LSP-marksman",
 			"labels": [


### PR DESCRIPTION
Adds the LSP-MaaFramework helper for MaaFramework pipeline projects. The entry uses the reviewed v0.3.0 release asset because the maintained source repository is a monorepo. Supports Sublime Text 4 on all platforms.